### PR TITLE
Adding LAPACK variant option to build

### DIFF
--- a/recipe/lapack_build.patch
+++ b/recipe/lapack_build.patch
@@ -1,0 +1,63 @@
+diff --git a/celerite/build.py b/celerite/build.py
+index d2f51b6..d29902f 100644
+--- a/celerite/build.py
++++ b/celerite/build.py
+@@ -7,6 +7,7 @@ import re
+ import sys
+ import logging
+ import tempfile
++from numpy.distutils.system_info import get_info
+ 
+ import setuptools
+ from setuptools.command.build_ext import build_ext as _build_ext
+@@ -169,21 +170,19 @@ class build_ext(_build_ext):
+             ext.extra_compile_args = opts
+ 
+         # Link to numpy's LAPACK if available
+-        info = None
+-        for ext in self.extensions:
+-            if not any(k[0] == "WITH_LAPACK" for k in ext.define_macros):
+-                continue
+-            if info is None:
+-                import pprint
+-                import numpy.__config__ as npconf
+-                info = npconf.get_info("blas_opt_info")
+-                print("Found LAPACK linking info:")
+-                pprint.pprint(info)
+-            for k, v in info.items():
+-                try:
+-                    setattr(ext, k, getattr(ext, k) + v)
+-                except TypeError:
+-                    continue
++        variant = os.environ.get("LAPACK_VARIANT", None)
++        if variant is not None and variant.lower() != "none":
++            info = get_info(variant)
++            if not len(info):
++                logging.warn("LAPACK info for variant '{0}' not found")
++                info = get_info("blas_opt")
++            for ext in self.extensions:
++                for k, v in info.items():
++                    try:
++                        setattr(ext, k, getattr(ext, k) + v)
++                    except TypeError:
++                        continue
++                ext.define_macros += [("WITH_LAPACK", None)]
+ 
+         # Run the standard build procedure.
+         _build_ext.build_extension(self, ext)
+diff --git a/setup.py b/setup.py
+index 1b08e0e..c99fa36 100644
+--- a/setup.py
++++ b/setup.py
+@@ -30,11 +30,6 @@ compile_args["include_dirs"] = [
+     numpy.get_include(),
+ ]
+ 
+-# Check for LAPACK argument
+-if "--lapack" in sys.argv:
+-    sys.argv.pop(sys.argv.index("--lapack"))
+-    compile_args["define_macros"] += [("WITH_LAPACK", None)]
+-
+ ext = Extension("celerite.solver",
+                 sources=[os.path.join("celerite", "solver.cpp")],
+                 language="c++",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "celerite" %}
 {% set version = "0.1.1" %}
 {% set sha256 = "3f5c4920aa09f81b3552a1c12945ea336126087eedf0114ae894643d2a55ee5d" %}
-{% set variant = "openblas" %}
+{% set variant = "mkl" %}
 
 package:
   name: {{ name|lower }}
@@ -11,11 +11,13 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - lapack_build.patch
 
 build:
-  number: 0
+  number: 1
   script:
-    - python setup.py install --single-version-externally-managed --record record.txt --lapack  # [not win]
+    - LAPACK_VARIANT={{ variant }} python setup.py install --single-version-externally-managed --record record.txt  # [not win]
   features:
     - blas_{{ variant }}  # [not win]
 
@@ -26,13 +28,15 @@ requirements:
     - toolchain
     - eigen
     - pybind11
-    - blas 1.1 {{ variant }}  # [not win]
-    - openblas 0.2.19|0.2.19.*  # [not win]
+    - mkl 2017.0.1  # [not win]
+    #- blas 1.1 {{ variant }}  # [not win]
+    #- openblas 0.2.19|0.2.19.*  # [not win]
     - numpy x.x
   run:
     - python
-    - blas 1.1 {{ variant }}  # [not win]
-    - openblas 0.2.19|0.2.19.*  # [not win]
+    - mkl 2017.0.1  # [not win]
+    #- blas 1.1 {{ variant }}  # [not win]
+    #- openblas 0.2.19|0.2.19.*  # [not win]
     - numpy x.x
     - setuptools  # [win]
     - vs2015_runtime  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,6 @@ build:
   number: 1
   script:
     - LAPACK_VARIANT={{ variant }} python setup.py install --single-version-externally-managed --record record.txt  # [not win]
-  features:
-    - blas_{{ variant }}  # [not win]
 
 requirements:
   build:


### PR DESCRIPTION
The MKL library from "defaults" seems to substantially outperform "openblas" on all systems. Let's see if we can implement that here.